### PR TITLE
Core Continuum Changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>1.15.0-rc2</version>

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -56,6 +56,10 @@ public class JdbcSinkConnector extends SinkConnector {
 
   @Override
   public void stop() {
+    if (JdbcSinkTask.continuumProducer != null) {
+      log.debug("Stopping JdbcSinkConnector... Continuum producer detected, closing producer.");
+      JdbcSinkTask.continuumProducer.close();
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -192,6 +192,11 @@ public class JdbcSourceConnector extends SourceConnector {
         }
       }
     }
+
+    if (JdbcSourceTask.continuumProducer != null) {
+      log.debug("Stopping JdbcSourceTask... Continuum producer detected, closing producer.");
+      JdbcSourceTask.continuumProducer.close();
+    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuum.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuum.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.continuum;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG;
+
+public class JdbcContinuum {
+  private static final Logger log = LoggerFactory.getLogger(JdbcContinuum.class);
+
+  private Producer<Object, Object> producer;
+  private String topic;
+  private String label;
+  private Schema valueSchema;
+
+  public JdbcContinuum(AbstractConfig config) {
+    final JdbcContinuumConfigValues continuumConfig = JdbcContinuumConfig.parseConfigValues(config);
+
+    if (continuumConfig.isConfigured()) {
+      Properties props = new Properties();
+      props.put(BOOTSTRAP_SERVERS_CONFIG, continuumConfig.bootstrapServers);
+      props.put(SCHEMA_REGISTRY_URL_CONFIG, continuumConfig.schemaRegistryURL);
+      props.put(KEY_SERIALIZER_CLASS_CONFIG,
+          org.apache.kafka.common.serialization.StringSerializer.class);
+      props.put(VALUE_SERIALIZER_CLASS_CONFIG,
+          io.confluent.kafka.serializers.KafkaAvroSerializer.class);
+      producer = new KafkaProducer<>(props);
+
+      String statusSchema = 
+          "{\"type\":\"record\","
+          + "\"name\":\"" + continuumConfig.topic + "-continuum\","
+          + "\"fields\":["
+          + "{\"name\":\"target\",\"type\":\"string\"},"
+          + "{\"name\":\"statusCode\",\"type\":\"int\"}"
+          + "]}";
+      Schema.Parser parser = new Schema.Parser();
+      valueSchema = parser.parse(statusSchema);
+
+      topic = continuumConfig.topic;
+      label = continuumConfig.label;
+
+      log.info("Created Continuum producer with topic {}", topic);
+    } else {
+      log.info("No Continuum producer created");
+    }
+  }
+
+  public boolean isActive() {
+    return producer != null;
+  }
+
+  public void produce(String key, Integer statusCode) {
+    GenericRecord value = new GenericData.Record(valueSchema);
+    value.put("target", label);
+    value.put("statusCode", statusCode);
+
+    producer.send(new ProducerRecord<Object, Object>(topic, key, value));
+  }
+
+  public void close() {
+    if (producer != null) {
+      producer.close();
+      producer = null;
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumConfig.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.continuum;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Validator;
+import org.apache.kafka.common.config.ConfigException;
+
+import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
+
+public class JdbcContinuumConfig {
+  private static final String CONTINUUM_GROUP = "Continuum";
+
+  public static final String CONTINUUM_TOPIC_CONFIG = 
+      "continuum.topic";
+  private static final String CONTINUUM_TOPIC_DOC =
+      "The topic to send events to once the record is processed.";
+  private static final String CONTINUUM_TOPIC_DISPLAY =
+      "Continuum Topic";
+
+  public static final String CONTINUUM_LABEL_CONFIG =
+      "continuum.label";
+  private static final String CONTINUUM_LABEL_DOC =
+      "The label associated with the completion of this sink connector record processing.";
+  private static final String CONTINUUM_LABEL_DISPLAY =
+      "Continuum Label";
+
+  public static final String CONTINUUM_BOOTSTRAP_SERVERS_CONFIG =
+      "continuum.bootstrap.servers";
+  private static final String CONTINUUM_BOOTSTRAP_SERVERS_DOC =
+      "The initial Kafka brokers to established connection to for the continuum topic.";
+  private static final String CONTINUUM_BOOTSTRAP_SERVERS_DISPLAY = 
+      "Continuum Bootstrap Servers";
+
+  public static final String CONTINUUM_SCHEMA_REGISTRY_URL_CONFIG =
+      "continuum.schema.registry.url";
+  private static final String CONTINUUM_SCHEMA_REGISTRY_URL_DOC =
+      "The schema registry service.";
+  private static final String CONTINUUM_SCHEMA_REGISTRY_URL_DISPLAY = 
+      "Continuum Schema Registry";
+
+  public static JdbcContinuumConfigValues parseConfigValues(AbstractConfig config) {
+    JdbcContinuumConfigValues values = new JdbcContinuumConfigValues();
+
+    values.topic = config
+        .getString(JdbcContinuumConfig.CONTINUUM_TOPIC_CONFIG)
+        .trim();
+    values.label = config
+        .getString(JdbcContinuumConfig.CONTINUUM_LABEL_CONFIG)
+        .trim();
+    values.bootstrapServers = config
+        .getString(JdbcContinuumConfig.CONTINUUM_BOOTSTRAP_SERVERS_CONFIG);
+    values.schemaRegistryURL = config
+        .getString(JdbcContinuumConfig.CONTINUUM_SCHEMA_REGISTRY_URL_CONFIG);
+
+    return values;
+  }
+
+  public static ConfigDef continuumDefs(ConfigDef defs) {
+    return defs
+      .define(
+        CONTINUUM_BOOTSTRAP_SERVERS_CONFIG,
+        ConfigDef.Type.STRING,
+        "",
+        ConfigDef.Importance.LOW,
+        CONTINUUM_BOOTSTRAP_SERVERS_DOC,
+        CONTINUUM_GROUP,
+        1,
+        ConfigDef.Width.MEDIUM,
+        CONTINUUM_BOOTSTRAP_SERVERS_DISPLAY
+      ).define(
+        CONTINUUM_SCHEMA_REGISTRY_URL_CONFIG,
+        ConfigDef.Type.STRING,
+        "",
+        ConfigDef.Importance.LOW,
+        CONTINUUM_SCHEMA_REGISTRY_URL_DOC,
+        CONTINUUM_GROUP,
+        2,
+        ConfigDef.Width.MEDIUM,
+        CONTINUUM_SCHEMA_REGISTRY_URL_DISPLAY
+      ).define(
+        CONTINUUM_TOPIC_CONFIG,
+        ConfigDef.Type.STRING,
+        "",
+        new Validator() {
+          @Override
+          public void ensureValid(final String name, final Object value) {
+            if (value == null) {
+              return;
+            }
+
+            String trimmed = ((String) value).trim();
+
+            if (trimmed.length() > 249) {
+              throw new ConfigException(name, value,
+                  "Continuum topic length must not exceed max topic name length, 249 chars");
+            }
+
+            if (JdbcSourceConnectorConfig.INVALID_CHARS.matcher(trimmed).find()) {
+              throw new ConfigException(name, value,
+                  "Continuum topic must not contain any character other than "
+                  + "ASCII alphanumerics, '.', '_' and '-'.");
+            }
+          }
+        },
+        ConfigDef.Importance.LOW,
+        CONTINUUM_TOPIC_DOC,
+        CONTINUUM_GROUP,
+        3,
+        ConfigDef.Width.MEDIUM,
+        CONTINUUM_TOPIC_DISPLAY
+      ).define(
+        CONTINUUM_LABEL_CONFIG,
+        ConfigDef.Type.STRING,
+        "JdbcConnector",
+        ConfigDef.Importance.LOW,
+        CONTINUUM_LABEL_DOC,
+        CONTINUUM_GROUP,
+        4,
+        ConfigDef.Width.MEDIUM,
+        CONTINUUM_LABEL_DISPLAY);
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumConfigValues.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumConfigValues.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.continuum;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+
+public class JdbcContinuumConfigValues {
+  private static final Logger log = LoggerFactory.getLogger(JdbcContinuumConfigValues.class);
+
+  public String topic;
+  public String label;
+  public String bootstrapServers;
+  public String schemaRegistryURL;
+
+  public boolean isConfigured() {
+    if (topic != "" || bootstrapServers != "" || schemaRegistryURL != "") {
+      ArrayList<String> missingValues = new ArrayList<String>();
+
+      if (topic == "") {
+        missingValues.add(JdbcContinuumConfig.CONTINUUM_TOPIC_CONFIG);
+      }
+      if (bootstrapServers == "") {
+        missingValues.add(JdbcContinuumConfig.CONTINUUM_BOOTSTRAP_SERVERS_CONFIG);
+      }
+      if (schemaRegistryURL == "") {
+        missingValues.add(JdbcContinuumConfig.CONTINUUM_SCHEMA_REGISTRY_URL_CONFIG);
+      }
+
+      if (missingValues.size() > 0) {
+        log.warn("Continuum properties are partially configured. The following "
+            + "properties need to be configured to work: {}",  
+            String.join(",", missingValues));
+        return false;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSink.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSink.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.continuum;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class JdbcContinuumSink extends JdbcContinuum {
+  private static final Logger log = LoggerFactory.getLogger(JdbcContinuumSink.class);
+
+  public JdbcContinuumSink(AbstractConfig config) {
+    super(config);
+  }
+
+  public void continueOn(Collection<SinkRecord> records, Integer statusCode) {
+    if (isActive()) {
+      try {
+        log.debug("Signalling sink continuum for {} records with status code {}", 
+            records.size(), statusCode);
+        for (SinkRecord record : records) {
+          log.trace("Signalling sink continuum for {}", record.value());
+
+          String key = record.key().toString();
+          
+          produce(key, statusCode);
+        }
+      } catch (IllegalStateException e) {
+        log.error("Fatal: Cannot produce Continuum record", e);
+        close();
+      }
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSource.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSource.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.continuum;
+
+import java.util.Collection;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.confluent.connect.jdbc.source.JdbcSourceTaskConfig;
+
+public class JdbcContinuumSource extends JdbcContinuum {
+  private static final Logger log = LoggerFactory.getLogger(JdbcContinuumSource.class);
+
+  private String incrementingColumnName;
+
+  public JdbcContinuumSource(AbstractConfig config) {
+    super(config);
+
+    if (isActive()) {
+      incrementingColumnName = config.getString(
+          JdbcSourceTaskConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+    }
+  }
+
+  public void continueOn(Collection<SourceRecord> records, Integer statusCode) {
+    if (isActive()) {
+      try {
+        log.debug("Signalling source continuum for {} records with status code {}", 
+            records.size(), statusCode);
+        for (SourceRecord record : records) {
+          log.trace("Signalling source continuum for {}", record.value());
+
+          Struct recordValue = (Struct) record.value();
+          String key = recordValue.get(incrementingColumnName).toString();
+
+          produce(key, statusCode);
+        }
+      } catch (IllegalStateException e) {
+        log.error("Fatal: Cannot produce Continuum record", e);
+        close();
+      }
+    }
+  }
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
+import io.confluent.connect.jdbc.continuum.JdbcContinuumConfig;
 import io.confluent.connect.jdbc.source.JdbcSourceConnectorConfig;
 
 import io.confluent.connect.jdbc.util.ConfigUtils;
@@ -260,7 +261,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final EnumRecommender TABLE_TYPES_RECOMMENDER =
       EnumRecommender.in(TableType.values());
 
-  public static final ConfigDef CONFIG_DEF = new ConfigDef()
+  public static final ConfigDef CONFIG_DEF = JdbcContinuumConfig.continuumDefs(new ConfigDef()
         // Connection
         .define(
             CONNECTION_URL,
@@ -490,8 +491,8 @@ public class JdbcSinkConfig extends AbstractConfig {
             2,
             ConfigDef.Width.SHORT,
             RETRY_BACKOFF_MS_DISPLAY
-        );
-
+        ));
+        
   public final String connectorName;
   public final String connectionUrl;
   public final String connectionUser;

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.jdbc.source;
 
+import io.confluent.connect.jdbc.continuum.JdbcContinuumConfig;
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.dialect.DatabaseDialects;
 import io.confluent.connect.jdbc.util.TableId;
@@ -52,7 +53,7 @@ import org.slf4j.LoggerFactory;
 public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceConnectorConfig.class);
-  private static Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z0-9._-]");
+  public static Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z0-9._-]");
 
   public static final String CONNECTION_PREFIX = "connection.";
 
@@ -551,7 +552,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   private static final void addConnectorOptions(ConfigDef config) {
     int orderInGroup = 0;
-    config.define(
+    JdbcContinuumConfig.continuumDefs(config.define(
         TABLE_TYPE_CONFIG,
         Type.LIST,
         TABLE_TYPE_DEFAULT,
@@ -642,7 +643,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         CONNECTOR_GROUP,
         ++orderInGroup,
         Width.MEDIUM,
-        DB_TIMEZONE_CONFIG_DISPLAY);
+        DB_TIMEZONE_CONFIG_DISPLAY));
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();


### PR DESCRIPTION
Implements the core changes to the Jdbc connector for the continuum feature to work. It added the configuration definitions, producer initialization, producer events, and the deinitialization logic.

Missing other configuration properties for the Continuum topic, such as the broker security parameters.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
