### PR TITLE
Fixed Static Producer

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSinkConnector.java
@@ -56,10 +56,6 @@ public class JdbcSinkConnector extends SinkConnector {
 
   @Override
   public void stop() {
-    if (JdbcSinkTask.continuumProducer != null) {
-      log.debug("Stopping JdbcSinkConnector... Continuum producer detected, closing producer.");
-      JdbcSinkTask.continuumProducer.close();
-    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/confluent/connect/jdbc/JdbcSourceConnector.java
@@ -192,11 +192,6 @@ public class JdbcSourceConnector extends SourceConnector {
         }
       }
     }
-
-    if (JdbcSourceTask.continuumProducer != null) {
-      log.debug("Stopping JdbcSourceTask... Continuum producer detected, closing producer.");
-      JdbcSourceTask.continuumProducer.close();
-    }
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuum.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuum.java
@@ -85,10 +85,16 @@ public class JdbcContinuum {
     producer.send(new ProducerRecord<Object, Object>(topic, key, value));
   }
 
-  public void close() {
+  public void stop() {
     if (producer != null) {
-      producer.close();
-      producer = null;
+      log.debug("Stopping JdbcContinuum... Continuum producer detected, closing producer.");
+      try {
+        producer.close();
+      } catch (Throwable t) {
+        log.warn("Error while closing the {} continuum producer: ", label, t);
+      } finally {
+        producer = null;
+      }
     }
   }
 }

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSink.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSink.java
@@ -43,7 +43,7 @@ public class JdbcContinuumSink extends JdbcContinuum {
         }
       } catch (IllegalStateException e) {
         log.error("Fatal: Cannot produce Continuum record", e);
-        close();
+        stop();
       }
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSource.java
+++ b/src/main/java/io/confluent/connect/jdbc/continuum/JdbcContinuumSource.java
@@ -54,7 +54,7 @@ public class JdbcContinuumSource extends JdbcContinuum {
         }
       } catch (IllegalStateException e) {
         log.error("Fatal: Cannot produce Continuum record", e);
-        close();
+        stop();
       }
     }
   }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -40,7 +40,7 @@ public class JdbcSinkTask extends SinkTask {
   JdbcSinkConfig config;
   JdbcDbWriter writer;
   int remainingRetries;
-  public static JdbcContinuumSink continuumProducer;
+  public JdbcContinuumSink continuumProducer;
 
   @Override
   public void start(final Map<String, String> props) {
@@ -139,6 +139,8 @@ public class JdbcSinkTask extends SinkTask {
         dialect = null;
       }
     }
+
+    continuumProducer.stop();
   }
 
   @Override

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -322,6 +322,9 @@ public class JdbcSourceTask extends SourceTask {
   public void stop() throws ConnectException {
     log.info("Stopping JDBC source task");
     running.set(false);
+    
+    continuumProducer.stop();
+
     // All resources are closed at the end of 'poll()' when no longer running or
     // if there is an error
   }


### PR DESCRIPTION
Having the producer static per task type (source/sink) cause it to only allow only one configuration. Removing it from being static resolved this issue.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
